### PR TITLE
v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-ci",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Simplified Firebase interaction for continuous integration including deploying hosting, functions, and database/storage rules.",
   "main": "lib/index.js",
   "bin": {

--- a/src/actions/createConfig.js
+++ b/src/actions/createConfig.js
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { reduce, template, mapValues, get } from 'lodash'
+import { reduce, template, mapValues, get, isString } from 'lodash'
 import { getFile } from '../utils/files'
 import { error, info, warn } from '../utils/logger'
 
@@ -27,8 +27,7 @@ export default (config) => {
   const settings = getFile('.firebaserc')
 
   if (!TRAVIS_BRANCH) {
-    warn('Creating config is currently only supported in CI environment')
-    return
+    warn('Not in CI Environment. Defaulting to settings for master branch...')
   }
 
   if (!settings) {
@@ -43,30 +42,40 @@ export default (config) => {
 
   const opts = {
     path: get(config, 'path', './src/config.js'),
-    branch: get(config, 'branch', TRAVIS_BRANCH)
+    branch: get(config, 'branch', TRAVIS_BRANCH || 'master')
   }
 
   info(`Attempting to load config for ${opts.branch}`)
 
   if (!settings.ci.createConfig[opts.branch]) {
-    error('Matching branch does not exist in create config settings')
-    throw new Error('Matching branch does not exist in create config settings')
+    const missingMsg = 'Matching branch does not exist in create config settings'
+    error(missingMsg)
+    throw new Error(missingMsg)
   }
 
   info(`Creating config file at path: ${opts.path}`)
 
   const envConfig = settings.ci.createConfig[opts.branch]
-  // template data based on environment variables
-  const templatedData = mapValues(envConfig, parent =>
-    mapValues(parent, (data, childKey) => template(data)(process.env) || data)
-  )
+  let templatedData
+  try {
+    // template data based on environment variables
+    templatedData = mapValues(envConfig, (parent) =>
+      isString(parent)
+        ? template(parent)(process.env)
+        : mapValues(parent, (data, childKey) => template(data)(process.env) || data)
+    )
+  } catch (err) {
+    error('Error while creating config:', err.toString())
+  }
   // convert object into formatted object string
   const parentAsString = (parent) => reduce(parent, (acc, child, childKey) =>
     acc.concat(`  ${childKey}: ${JSON.stringify(child, null, 2)},\n`)
   , '')
+
   // combine all stringified vars and attach default export
   const exportString = reduce(templatedData, (acc, parent, parentName) =>
-    acc.concat(`export const ${parentName} = {\n${parentAsString(parent)}};\n\n`)
+    acc.concat(`export const ${parentName} = `)
+      .concat(isString(parent) ? `"${parent}";\n\n` : `{\n${parentAsString(parent)}};\n\n`)
   , '').concat(`export default { ${Object.keys(templatedData).join(', ')} }`)
 
   try {


### PR DESCRIPTION
* Support running `createConfig` outside of CI environment (for setting up local dev)
* Fix issue with missing environment variable used in template (sets empty string instead)
* Fix issue with strings not templating correctly (converting to object)