### PR TITLE
bug(createConfig): envConfig fails because opts.project is defined bu…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-ci",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Simplified Firebase interaction for continuous integration including deploying hosting, functions, and database/storage rules.",
   "main": "lib/index.js",
   "bin": {

--- a/src/actions/createConfig.js
+++ b/src/actions/createConfig.js
@@ -66,7 +66,7 @@ export default (config) => {
     info(`Project named "${opts.project}" does not exist in create config settings, falling back to ${fallBackConfigName}`)
   }
 
-  const envConfig = createConfig[opts.project || fallBackConfigName]
+  const envConfig = createConfig[opts.project] ? createConfig[opts.project] : createConfig[fallBackConfigName]
 
   if (!envConfig) {
     const msg = 'Valid create config settings could not be loaded'


### PR DESCRIPTION
…t doesn't exist

### Description

When running in a CI environment (CircleCI), `opts.project` gets set by the `<CI>_BRANCH` variable. When the branch is not a valid project configuration this fails:

```javascript
const envConfig = createConfig[opts.project || fallBackConfigName]
```
since opts.project is not `undefined`

Changing this to:
```javascript
 const envConfig = createConfig[opts.project] ? createConfig[opts.project] : createConfig[fallBackConfigName]
```
fixes the issue as it validates that its a valid object node.

### Check List

- [x] All test passed
- [x] Added test to ensure to fix/ensure properly.
