### PR TITLE
v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@
     }
     ```
 
-
 ## Setting Project
+
 There are a number of ways to set which Firebase project within `.firebaserc` is being used when running actions. Below is the order of for how the project is determined (default at bottom):
 
 * `FIREBASE_CI_PROJECT` environment variable (overrides all)
@@ -86,27 +86,30 @@ Default installation uses `@latest` tag, but there are also others:
 * [Basic](/examples/basic) - Basic html file upload to Firebase hosting of different projects (or "environments")
 
 ## Why?
+
 Advanced configuration of Firebase deployment is often necessary when deploying through continuous integration environment. Instead of having to write and invoke your own scripts, `firebase-ci` provides an easy way to  create/modify advanced configurations.
 
-### What about [Travis's `firebase`](https://docs.travis-ci.com/user/deployment/firebase/) deploy option?
+## FAQ
 
-Using the built in [travis firebase deploy tool](https://docs.travis-ci.com/user/deployment/firebase/) is actually a perfect solution if you want to do general deployment. You can even include the following to install stuff functions dependencies on Travis:
+1. What about [Travis's `firebase`](https://docs.travis-ci.com/user/deployment/firebase/) deploy option?
 
-```yaml
-after_success:
-  - npm install --prefix ./functions
+    Using the built in [travis firebase deploy tool](https://docs.travis-ci.com/user/deployment/firebase/) is actually a perfect solution if you want to do general deployment. You can even include the following to install stuff functions dependencies on Travis:
 
-deploy:
-  provider: firebase
-  project: $TRAVIS_BRANCH
-  skip_cleanup: true
-  token:
-    secure: $FIREBASE_TOKEN
-```
+    ```yaml
+    after_success:
+      - npm install --prefix ./functions
 
-This lets you deploy to whatever instance you want based on your branch (and config in `.firebaserc`).
+    deploy:
+      provider: firebase
+      project: $TRAVIS_BRANCH
+      skip_cleanup: true
+      token:
+        secure: $FIREBASE_TOKEN
+    ```
 
-`firebase-ci` is for more advanced implementations including only deploying functions, hosting
+    This lets you deploy to whatever instance you want based on your branch (and config in `.firebaserc`).
+
+    `firebase-ci` is for more advanced implementations including only deploying functions, hosting
 
 ## Commands
 
@@ -114,7 +117,7 @@ This lets you deploy to whatever instance you want based on your branch (and con
 * [`createConfig`](#createconfig) - Create a config file based on CI environment variables (defaults to `src/config.js`)
 * [`deploy`](#deploy) - Deploy to Firebase (runs other actions by default)
 * [`mapEnv`](#mapenv) - Map environment variables from CI Environment to Firebase functions environment
-
+* [`project`](#project) - Output project name associated with CI environment (useful for commands that should be run for each environment)
 
 ### copyVersion
 
@@ -217,9 +220,8 @@ Provide extra information from internal actions (including npm install of `fireb
 If you have a functions folder, your functions will automatically deploy as part of using `firebase-ci`. For skipping this functionality, you may use the only flag, similar to the API of `firebase-tools`.
 
 ```yaml
-after_success:
-  - npm i -g firebase-ci
-  - firebase-ci deploy --only hosting
+script:
+  - $(npm bin)/firebase-ci deploy --only hosting
 ```
 
 ### mapEnv
@@ -250,15 +252,29 @@ CI variable is SOME_TOKEN="asdf" and you would like to set it to `some.token` on
 Internally calls `firebase functions:config:set some.token="asdf"`. This will happen for every variable you provide within mapEnv.
 
 ### skipDependenciesInstall
+
 Skip installing of dependencies including `firebase-tools` and `node_modules` within `functions` folder
 
 ### skipToolsInstall
+
 Skip installing of `firebase-tools` (installed by default when calling `firebase-ci deploy` without simple mode)
 
 ### skipFunctionsInstall
+
 Skip running `npm install` within `functions` folder (`npm install` is called within `functions` folder by default when calling `firebase-ci deploy`).
 
+### project
+
+Get name of project associated with the CI environment
+
+##### Example
+
+```bash
+echo "Project to deploy to $(firebase-ci project)"
+```
+
 ### Roadmap
+
 * `setCORS` option for copying CORS config file to Cloud Storage Bucket
 * only setting non existent env vars with `mapEnv`
 * Support for Continuous Integration Tools other than Travis-CI

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Code Style][code-style-image]][code-style-url]
 
 ## Features
+
 * Skip For Pull Requests
 * Deploy to Different Firebase Instances based on Branch
 * Mapping of CI environment variables to Firebase Functions Config
@@ -20,23 +21,31 @@
 
 1. Generate a CI token through `firebase-tools` by running `firebase login:ci`
 1. Place this token within your CI environment under the variable `FIREBASE_TOKEN`
-1. Install `firebase-ci` into your project (so it is available on your CI): `npm install --save-dev firebase-ci`. You can also install `firebase-tools` locally so that the version is stored within your package file.
+1. Install `firebase-ci` into your project (so it is available on your CI): `npm install --save-dev firebase-ci firebase-tools`. If you don't want `firebase-tools` as a dev dependency, it can be left out as it is installed automatically if it doesn't exist.
+1. Add the following npm scripts:
+    ```json
+    "build:config": "firebase-ci createConfig",
+    "deploy": "firebase-ci deploy"
+    ```
+
 1. Add the following scripts to your CI config:
 
     ```bash
-    npm i firebase-tools  # install firebase-ci tool and firebase-tools
     firebase-ci deploy # deploys only on branches that have a matching project name in .firebaserc
     ```
 
     For instance within a `travis.yml`:
 
       ```yaml
-      after_success:
-        - npm i firebase-tools
-        - $(npm bin)/firebase-ci deploy
+      script:
+        - npm run build:config # Build src/config.js
+        - npm run lint # Check for lint
+        - npm run deploy # Deploy to Firebase
       ```
 
-    **NOTE**: `firebase-ci` can be used through the nodejs `bin` instead of being installed globally
+    **NOTES**:
+    * `firebase-ci` can be used through the nodejs `bin` **OR** installed globally
+    * `firebase-tools` will be installed (from `@latest`) if it is not already installed locally or globally
 
 1. Set different Firebase instances names to `.firebaserc` like so:
     ```json

--- a/cmds/createConfig.js
+++ b/cmds/createConfig.js
@@ -26,11 +26,11 @@ module.exports = function(program) {
       'Project within .firebaserc to use when creating config file. Defaults to "default" then to "master"'
     )
     .description(
-      'Build configuration file based on settings in .firebaserc. Uses TRAVIS_BRANCH to determine project from .firebaserc to use for config (falls back to "default" then to "master").'
+      'Build configuration file based on settings in .firebaserc. Uses environment variables to determine project from .firebaserc to use for config (falls back to "default" then to "master").'
     )
-    .action((directory, options) => {
+    .action(options => {
       try {
-        createConfig(program.args[0], directory, options)
+        createConfig({ project: typeof options === 'string' ? options : null })
         return process.exit(0)
       } catch (err) {
         return process.exit(1)

--- a/cmds/index.js
+++ b/cmds/index.js
@@ -11,6 +11,7 @@ module.exports = function(client) {
   client.copyVersion = loadCommand('copyVersion')
   client.mapEnv = loadCommand('mapEnv')
   client.run = loadCommand('run')
+  client.project = loadCommand('project')
 
   return client
 }

--- a/cmds/project.js
+++ b/cmds/project.js
@@ -1,20 +1,12 @@
-/* deploy commander component
- * To use add require('../cmds/deploy.js')(program) to your commander.js based node executable before program.parse
- */
 'use strict'
 const getProjectName = require('../lib/utils/ci').getProjectName
 
 /**
- * @name mapEnv
- * @description Map environment variables from CI environment to functions config
+ * @name project
+ * @description Get name of the firebase project associated with the current CI environment.
  * @example <caption>Basic</caption>
- * # make sure you set mapEnv settings in .firebaserc
- * npm i -g firebase-ci
- * firebase-ci mapEnv
- * @example <caption>Travis</caption>
- * after_success:
- *   - npm i -g firebase-ci
- *   - firebase-ci mapEnv
+ * echo "Project to deploy to $(firebase-ci project)"
+ * // => "Project to deploy to my-project"
  */
 module.exports = function(program) {
   program

--- a/cmds/project.js
+++ b/cmds/project.js
@@ -1,0 +1,32 @@
+/* deploy commander component
+ * To use add require('../cmds/deploy.js')(program) to your commander.js based node executable before program.parse
+ */
+'use strict'
+const getProjectName = require('../lib/utils/ci').getProjectName
+
+/**
+ * @name mapEnv
+ * @description Map environment variables from CI environment to functions config
+ * @example <caption>Basic</caption>
+ * # make sure you set mapEnv settings in .firebaserc
+ * npm i -g firebase-ci
+ * firebase-ci mapEnv
+ * @example <caption>Travis</caption>
+ * after_success:
+ *   - npm i -g firebase-ci
+ *   - firebase-ci mapEnv
+ */
+module.exports = function(program) {
+  program
+    .command('project')
+    .description('Get name of project associated with current CI environment')
+    .action((directory, options) => {
+      const projectKey = getProjectName()
+      if (!projectKey) {
+        process.exit(1)
+      } else {
+        console.log(projectKey) // eslint-disable-line no-console
+        process.exit(0)
+      }
+    })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-ci",
-  "version": "0.5.0-beta.3",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-ci",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Simplified Firebase interaction for continuous integration including deploying hosting, functions, and database/storage rules.",
   "main": "lib/index.js",
   "bin": {

--- a/src/actions/createConfig.js
+++ b/src/actions/createConfig.js
@@ -6,13 +6,7 @@ import { getFile } from '../utils/files'
 import { error, info, warn } from '../utils/logger'
 import { getProjectKey } from '../utils/ci'
 
-const {
-  FIREBASE_CI_PROJECT,
-  TRAVIS_BRANCH,
-  CIRCLE_BRANCH,
-  CI_COMMIT_REF_SLUG,
-  CI_ENVIRONMENT_SLUG
-} = process.env
+const { CI_ENVIRONMENT_SLUG } = process.env
 
 function formattedErrorMessage(err) {
   const errMessage = get(err, 'message', 'Issue templating config file')
@@ -23,19 +17,9 @@ function formattedErrorMessage(err) {
   return `${chalk.cyan(splitMessage[0])} is not defined in environment`
 }
 
-function getProjectPackageFile() {
-  const packageFilePath = path.join(process.cwd(), 'package.json')
-  try {
-    const fileStr = fs.readFileSync(packageFilePath)
-    return JSON.parse(fileStr)
-  } catch (err) {
-    error('Unable to load project package.json file', err)
-    return null
-  }
-}
-
 function tryTemplating(str, name) {
-  const { version } = getProjectPackageFile() || {}
+  const packageFilePath = path.join(process.cwd(), 'package.json')
+  const { version } = getFile(packageFilePath)
   try {
     return template(str)({ ...process.env, version })
   } catch (err) {

--- a/src/actions/createConfig.js
+++ b/src/actions/createConfig.js
@@ -18,10 +18,13 @@ function formattedErrorMessage(err) {
 }
 
 function tryTemplating(str, name) {
-  const packageFilePath = path.join(process.cwd(), 'package.json')
-  const { version } = getFile(packageFilePath)
+  const { version } = getFile('package.json')
   try {
-    return template(str)({ ...process.env, version })
+    return template(str)({
+      ...process.env,
+      version,
+      npm_package_version: version
+    })
   } catch (err) {
     const errMsg = formattedErrorMessage(err)
     warn(`${errMsg}. Setting ${chalk.cyan(name)} to an empty string.`)

--- a/src/actions/deploy.js
+++ b/src/actions/deploy.js
@@ -29,13 +29,17 @@ export function runActions() {
   if (functionsExists() && settings.ci && settings.ci.mapEnv) {
     return mapEnv().catch(err => {
       error(
-        'Error mapping CI environment variables to Functions environment: ',
+        'Could not map CI environment variables to Functions environment: ',
         err
       )
       return Promise.reject(err)
     })
   }
-  info('No ci action settings found in .firebaserc. Skipping action phase.')
+  info(
+    `No ci action settings found in ${chalk.cyan(
+      '.firebaserc'
+    )}. Skipping action phase.`
+  )
   return Promise.resolve({})
 }
 
@@ -106,14 +110,15 @@ export default async function deploy(opts) {
   // Handle FIREBASE_TOKEN not existing within environment variables
   const { FIREBASE_TOKEN } = process.env
   if (!FIREBASE_TOKEN) {
-    error('Error: FIREBASE_TOKEN env variable not found.')
+    error(`${chalk.cyan('FIREBASE_TOKEN')} environment variable not found`)
     info(
-      `Run ${chalk.cyan(
+      `To Fix: Run ${chalk.cyan(
         'firebase login:ci'
-      )} (from  firebase-tools) to generate a token` +
-        'and place it travis environment variables as FIREBASE_TOKEN'
+      )} (from firebase-tools) to generate a token then place it CI environment variables as ${chalk.cyan(
+        'FIREBASE_TOKEN'
+      )}`
     )
-    throw new Error('Error: FIREBASE_TOKEN env variable not found.')
+    throw new Error('FIREBASE_TOKEN env variable not found.')
   }
 
   const onlyString = opts && opts.only ? `--only ${opts.only}` : ''

--- a/src/actions/deploy.js
+++ b/src/actions/deploy.js
@@ -152,10 +152,11 @@ export default async function deploy(opts) {
   if (process.env.FIREBASE_CI_DEBUG || settings.debug) {
     deployArgs.concat(['--debug'])
   }
+
   // Run deploy command
   const [deployErr] = await to(
     runCommand({
-      command: npxExists ? 'npx' : '$(npm bin)/firebase',
+      command: npxExists ? 'npx' : 'firebase',
       args: npxExists ? ['firebase'].concat(deployArgs) : deployArgs,
       beforeMsg: `Deploying to ${branchName} branch to ${projectKey} Firebase project "${projectName}"`,
       errorMsg: 'Error deploying to firebase.',

--- a/src/utils/ci.js
+++ b/src/utils/ci.js
@@ -1,6 +1,7 @@
 import { get } from 'lodash'
 import { shellescape } from './commands'
-import { warn } from '../utils/logger'
+import { warn } from './logger'
+import { getFile } from './files'
 
 /**
  * Get the name of the current branch from environment variables
@@ -37,6 +38,16 @@ export function getProjectKey(opts) {
   return (
     FIREBASE_CI_PROJECT ||
     get(opts, 'project', branchName === 'master' ? 'default' : branchName)
+  )
+}
+
+export function getProjectName(opts) {
+  const projectKey = getProjectKey(opts)
+  const firebaserc = getFile('.firebaserc')
+  return get(
+    firebaserc,
+    `projects.${projectKey}`,
+    get(firebaserc, 'projects.master')
   )
 }
 

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -33,7 +33,8 @@ export function runCommand({
   return new Promise((resolve, reject) => {
     const child = spawn(
       isArray(command) ? command[0] : command.split(' ')[0],
-      args || compact(drop(command.split(' ')))
+      args || compact(drop(command.split(' '))),
+      { env: process.env }
     )
     let output
     let error

--- a/src/utils/deps.js
+++ b/src/utils/deps.js
@@ -1,7 +1,7 @@
+import commandExists from 'command-exists'
 import { functionsExists, functionsNodeModulesExist } from './files'
 import { runCommand } from './commands'
 import { to } from './async'
-import commandExists from 'command-exists'
 import { info as logInfo, error } from './logger'
 
 export function getNpxExists() {
@@ -21,7 +21,7 @@ export async function installDeps(opts = {}, settings = {}) {
   // globally installed versions of firebase-tools) falling back to npm bin
   const [versionErr, fbVersion] = await to(
     runCommand({
-      command: npxExists ? 'npx' : '$(npm bin)/firebase',
+      command: npxExists ? 'npx' : 'firebase',
       args: npxExists ? ['firebase', '--version'] : ['--version'],
       pipeOutput: false,
       beforeMsg: 'Checking to see if firebase-tools is installed...',
@@ -31,7 +31,7 @@ export async function installDeps(opts = {}, settings = {}) {
   if (versionErr) {
     const getVersionErrMsg =
       'Error attempting to check for firebase-tools version.'
-    error(getVersionErrMsg)
+    error(getVersionErrMsg, versionErr)
     throw new Error(getVersionErrMsg)
   }
   const promises = []

--- a/src/utils/files.js
+++ b/src/utils/files.js
@@ -1,12 +1,13 @@
 import chalk from 'chalk'
 import fs from 'fs'
 import path from 'path'
+import { error } from './logger'
 
 /**
  * Get settings from firebaserc file
  * @return {Object} Firebase settings object
  */
-export const getFile = filePath => {
+export function getFile(filePath) {
   const localPath = path.join(process.cwd(), filePath)
   if (!fs.existsSync(localPath)) {
     return {}
@@ -16,9 +17,8 @@ export const getFile = filePath => {
     return JSON.parse(fs.readFileSync(localPath, 'utf8'))
   } catch (err) {
     /* eslint-disable no-console */
-    console.log(
-      chalk.red(`Error parsing ${filePath}.`),
-      'JSON is most likley not valid'
+    error(
+      `Unable to parse ${chalk.cyan(filePath)} - JSON is most likley not valid`
     )
     /* eslint-enable no-console */
     return {}


### PR DESCRIPTION
### Description
* fix(deploy): improve package name parsing by gathering from `package.json` if available
* feat(createConfig): support project flag with `createConfig` command
* feat(project): add new `project` command to get the name of the project associated with the current environment
* fix(deploy): fix an issue where installing `firebase-tools` would not work on node 6 and earlier

### Check List

- [X] All test passed
- [X] Added test to ensure to fix/ensure properly.
